### PR TITLE
fix Ctrl+Enter keybinging

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
 			{
 				"command": "vscode-bigquery.run-query",
 				"key": "Ctrl+Enter",
-				"when": "resourceLangId == bqsql || editorLangId == bqsql"
+				"when": "editorLangId == bqsql"
 			}
 		]
 	},


### PR DESCRIPTION
reduce the scope of the Ctrl+F5 key binding. Was interfering with other vscode windows