### PR TITLE
Add BigQuery notebook support with execution and serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"onView:bigquery-main-activity-bar",
 		"onWebviewPanel:bigquery-table-results",
 		"onWebviewPanel:authentication-troubleshoot",
-		"onLanguage:bqsql"
+		"onLanguage:bqsql",
+		"onNotebook:bqnb"
 	],
 	"main": "./dist/extension.js",
 	"contributes": {
@@ -86,6 +87,15 @@
 			{
 				"language": "bqsql",
 				"path": "./resources/language/snippets.json"
+			}
+		],
+		"notebooks": [
+			{
+				"type": "bqnb",
+				"displayName": "BigQuery Notebook",
+				"selector": [
+					{ "filenamePattern": "*.bqnb" }
+				]
 			}
 		],
 		"configurationDefaults": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,8 @@ import { QueryResultsVisualizationType } from './services/queryResultsVisualizat
 import { TroubleshootSerializer } from './activitybar/troubleshootSerializer';
 import { GcpAuthenticationTreeDataProvider } from './activitybar/gcpAuthenticationTreeDataProvider';
 import { COMMAND_SEARCH, commandSearch } from './search/searchCommand';
+import { BqNotebookSerializer } from './notebook/bqNotebookSerializer';
+import { BqNotebookController } from './notebook/bqNotebookController';
 
 export const bigqueryWebviewViewProvider = new WebviewViewProvider();
 // export const authenticationWebviewProvider = new BigqueryAuthenticationWebviewViewProvider();
@@ -355,6 +357,15 @@ export function activate(context: ExtensionContext) {
 			new TroubleshootSerializer()
 		)
 	);
+
+	// bqnb notebook serializer
+	context.subscriptions.push(
+		vscode.workspace.registerNotebookSerializer('bqnb', new BqNotebookSerializer())
+	);
+
+	// bqnb notebook controller
+	const bqNotebookController = new BqNotebookController();
+	context.subscriptions.push({ dispose: () => bqNotebookController.dispose() });
 
 	//language
 	const baseDiagnostics = vscode.languages.createDiagnosticCollection('base_diagnostics');

--- a/src/notebook/bqNotebookController.ts
+++ b/src/notebook/bqNotebookController.ts
@@ -1,0 +1,205 @@
+import * as vscode from 'vscode';
+import { Job } from '@google-cloud/bigquery';
+import { getBigQueryClient } from '../extensionCommands';
+
+export class BqNotebookController {
+
+    private static readonly CONTROLLER_ID = 'bqnb-controller';
+    private static readonly NOTEBOOK_TYPE = 'bqnb';
+    private static readonly LABEL = 'BigQuery';
+
+    private readonly controller: vscode.NotebookController;
+
+    constructor() {
+        this.controller = vscode.notebooks.createNotebookController(
+            BqNotebookController.CONTROLLER_ID,
+            BqNotebookController.NOTEBOOK_TYPE,
+            BqNotebookController.LABEL
+        );
+        this.controller.supportedLanguages = ['bqsql', 'sql'];
+        this.controller.supportsExecutionOrder = true;
+        this.controller.executeHandler = this.execute.bind(this);
+    }
+
+    private async execute(
+        cells: vscode.NotebookCell[],
+        _notebook: vscode.NotebookDocument,
+        _controller: vscode.NotebookController
+    ): Promise<void> {
+        for (const cell of cells) {
+            await this.executeCell(cell);
+        }
+    }
+
+    private async executeCell(cell: vscode.NotebookCell): Promise<void> {
+        const execution = this.controller.createNotebookCellExecution(cell);
+        execution.start(Date.now());
+        await execution.clearOutput();
+
+        try {
+            const queryText = cell.document.getText();
+            const bqClient = await getBigQueryClient();
+            const job = await bqClient.runQuery(queryText);
+
+            // Poll until the job is complete
+            let metadata = job.metadata;
+            while (!metadata || metadata.status?.state !== 'DONE') {
+                await new Promise(r => setTimeout(r, 1000));
+                [metadata] = await job.getMetadata();
+            }
+            job.metadata = metadata;
+
+            // Check for job-level errors
+            if (metadata.status?.errorResult) {
+                const err = metadata.status.errorResult;
+                await execution.replaceOutput([
+                    new vscode.NotebookCellOutput([
+                        vscode.NotebookCellOutputItem.error({
+                            name: err.reason || 'BigQueryError',
+                            message: err.message || 'Query failed',
+                        })
+                    ])
+                ]);
+                execution.end(false, Date.now());
+                return;
+            }
+
+            const statementType: string = metadata.statistics?.query?.statementType || '';
+
+            if (statementType === 'SCRIPT') {
+                await this.handleScriptJob(execution, bqClient, job);
+            } else {
+                await this.handleSingleJob(execution, job);
+            }
+
+            execution.end(true, Date.now());
+
+        } catch (err: any) {
+            await execution.replaceOutput([
+                new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.error({
+                        name: 'BigQueryError',
+                        message: err.message || String(err),
+                    })
+                ])
+            ]);
+            execution.end(false, Date.now());
+        }
+    }
+
+    private async handleSingleJob(
+        execution: vscode.NotebookCellExecution,
+        job: Job
+    ): Promise<void> {
+        const statementType: string = job.metadata?.statistics?.query?.statementType || '';
+
+        if (!this.isSelectType(statementType)) {
+            // DML/DDL: show affected rows count
+            const affectedRows = job.metadata?.statistics?.query?.numDmlAffectedRows ?? null;
+            const msg = affectedRows !== null
+                ? `Statement completed. Rows affected: ${affectedRows}`
+                : 'Statement completed successfully.';
+            await execution.replaceOutput([
+                new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text(
+                        `<p style="font-style:italic;color:gray">${escapeHtml(msg)}</p>`,
+                        'text/html'
+                    )
+                ])
+            ]);
+            return;
+        }
+
+        const [rows] = await job.getQueryResults({ autoPaginate: true });
+        await execution.replaceOutput([
+            new vscode.NotebookCellOutput([
+                vscode.NotebookCellOutputItem.text(rowsToHtml(rows), 'text/html')
+            ])
+        ]);
+    }
+
+    private async handleScriptJob(
+        execution: vscode.NotebookCellExecution,
+        bqClient: Awaited<ReturnType<typeof getBigQueryClient>>,
+        parentJob: Job
+    ): Promise<void> {
+        const [childJobs] = await bqClient.bigQuery.getJobs({ parentJobId: parentJob.id });
+
+        const sortedJobs = (childJobs as Job[]).sort((a, b) => {
+            const id1 = a.id || '';
+            const id2 = b.id || '';
+            const n1 = Number(id1.substring(id1.lastIndexOf('_') + 1));
+            const n2 = Number(id2.substring(id2.lastIndexOf('_') + 1));
+            return n1 - n2;
+        });
+
+        const outputs: vscode.NotebookCellOutput[] = [];
+
+        for (const childJob of sortedJobs) {
+            const childStatementType: string = childJob.metadata?.statistics?.query?.statementType || '';
+
+            if (this.isSelectType(childStatementType)) {
+                const [rows] = await childJob.getQueryResults({ autoPaginate: true });
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text(rowsToHtml(rows), 'text/html')
+                ]));
+            } else if (childStatementType) {
+                // DML/DDL child statement: show affected rows
+                const affectedRows = childJob.metadata?.statistics?.query?.numDmlAffectedRows ?? null;
+                const msg = affectedRows !== null
+                    ? `Statement completed. Rows affected: ${affectedRows}`
+                    : 'Statement completed successfully.';
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text(
+                        `<p style="font-style:italic;color:gray">${escapeHtml(msg)}</p>`,
+                        'text/html'
+                    )
+                ]));
+            }
+        }
+
+        if (outputs.length > 0) {
+            await execution.replaceOutput(outputs);
+        }
+    }
+
+    private isSelectType(statementType: string): boolean {
+        return statementType === 'SELECT' || statementType === 'CREATE_TABLE_AS_SELECT';
+    }
+
+    dispose(): void {
+        this.controller.dispose();
+    }
+}
+
+function rowsToHtml(rows: any[]): string {
+    if (!rows || rows.length === 0) {
+        return '<p style="font-style:italic;color:gray">Query returned no results.</p>';
+    }
+
+    const columns = Object.keys(rows[0]);
+    const headerHtml = columns.map(c => `<th>${escapeHtml(c)}</th>`).join('');
+    const rowsHtml = rows.map(row => {
+        const cells = columns.map(c => `<td>${escapeHtml(String(row[c] ?? ''))}</td>`).join('');
+        return `<tr>${cells}</tr>`;
+    }).join('');
+
+    return `<style>
+table{border-collapse:collapse;font-family:monospace;font-size:12px}
+th{background:#444;color:#fff;padding:4px 8px;text-align:left}
+td{padding:4px 8px;border-bottom:1px solid #333}
+tr:nth-child(even) td{background:#1e1e1e}
+</style>
+<table>
+<thead><tr>${headerHtml}</tr></thead>
+<tbody>${rowsHtml}</tbody>
+</table>`;
+}
+
+function escapeHtml(str: string): string {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}

--- a/src/notebook/bqNotebookSerializer.ts
+++ b/src/notebook/bqNotebookSerializer.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+
+interface BqNotebookCellData {
+    kind: 'code' | 'markdown';
+    value: string;
+    language?: string;
+}
+
+interface BqNotebookFileFormat {
+    cells: BqNotebookCellData[];
+}
+
+export class BqNotebookSerializer implements vscode.NotebookSerializer {
+
+    async deserializeNotebook(content: Uint8Array, _token: vscode.CancellationToken): Promise<vscode.NotebookData> {
+        const text = new TextDecoder().decode(content);
+
+        let notebook: BqNotebookFileFormat;
+        try {
+            notebook = text.trim() ? JSON.parse(text) : { cells: [] };
+        } catch {
+            notebook = { cells: [] };
+        }
+
+        const cells = (notebook.cells ?? []).map(cell => {
+            const kind = cell.kind === 'markdown'
+                ? vscode.NotebookCellKind.Markup
+                : vscode.NotebookCellKind.Code;
+            return new vscode.NotebookCellData(kind, cell.value ?? '', cell.language ?? 'bqsql');
+        });
+
+        return new vscode.NotebookData(cells);
+    }
+
+    async serializeNotebook(data: vscode.NotebookData, _token: vscode.CancellationToken): Promise<Uint8Array> {
+        const cells: BqNotebookCellData[] = data.cells.map(cell => ({
+            kind: cell.kind === vscode.NotebookCellKind.Markup ? 'markdown' : 'code',
+            value: cell.value,
+            language: cell.languageId,
+        }));
+
+        const notebook: BqNotebookFileFormat = { cells };
+        return new TextEncoder().encode(JSON.stringify(notebook, null, 2));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds native notebook support to the BigQuery extension, allowing users to create and execute BigQuery SQL queries in VS Code notebooks with formatted result output.

## Key Changes
- **New Notebook Controller** (`bqNotebookController.ts`): Implements the core notebook execution engine that:
  - Executes BigQuery SQL queries from notebook cells
  - Polls job status until completion
  - Handles both single queries and BigQuery scripts with multiple child jobs
  - Renders query results as formatted HTML tables
  - Displays appropriate messages for DML/DDL statements with affected row counts
  - Provides error handling with detailed error output

- **New Notebook Serializer** (`bqNotebookSerializer.ts`): Handles persistence of notebook files (`.bqnb` format) by:
  - Deserializing JSON notebook files into VS Code notebook format
  - Serializing notebook data back to JSON with cell metadata
  - Supporting both code and markdown cell types

- **Extension Integration** (`extension.ts`): Registers the notebook type and wires up:
  - Notebook serializer for the `bqnb` type
  - Notebook controller for query execution
  - Proper subscription management for cleanup

- **Package Configuration** (`package.json`): Adds:
  - `onNotebook:bqnb` activation event
  - Notebook type definition with `.bqnb` file pattern association

## Notable Implementation Details
- Query results are rendered as styled HTML tables with alternating row colors and monospace font
- Script jobs are handled by fetching child jobs, sorting them by execution order, and displaying results for each statement
- Proper HTML escaping prevents injection vulnerabilities in output rendering
- Job polling uses 1-second intervals to check for completion status
- Error handling distinguishes between job-level errors and execution exceptions

https://claude.ai/code/session_01WyY3Hv7jeqeVLLuhr7hWGi