### PR TITLE
fix: include location parameter in getQueryResults API request

### DIFF
--- a/grid_render/src/bigquery/jobs.rs
+++ b/grid_render/src/bigquery/jobs.rs
@@ -393,9 +393,12 @@ impl Job {
 pub struct GetQueryResultsRequest {
     pub project_id: String,
     pub job_id: String,
+    /// The BigQuery region where the job was created (e.g. "southamerica-east1", "US", "EU").
+    /// Required for jobs outside the default US region — omitting it causes a 404 from the API.
+    /// See: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults
+    pub location: Option<String>,
     pub start_index: Option<String>,
     pub max_results: Option<usize>,
-    // formatOptions: DataFormatOptions;
 }
 
 #[derive(Debug)]
@@ -630,11 +633,17 @@ impl Jobs {
             request.project_id, request.job_id
         );
 
-        // if (request.location) { url.searchParams.append("location", request.location); }
         if request.max_results.is_some() {
             url = format!("{}?maxResults={}", url, request.max_results.unwrap());
         } else {
             url = format!("{}?maxResults=50", url);
+        }
+        // Append the `location` query parameter so the API can route the request to the correct
+        // region. Without this, jobs created outside the default US region return a 404.
+        if let Some(location) = &request.location {
+            if !location.is_empty() {
+                url = format!("{}&location={}", url, location);
+            }
         }
         if request.start_index.is_some() {
             url = format!("{}&startIndex={}", url, request.start_index.unwrap());

--- a/grid_render/src/custom_elements/bq_query_custom_element.rs
+++ b/grid_render/src/custom_elements/bq_query_custom_element.rs
@@ -158,6 +158,9 @@ impl BigqueryQueryCustomElement {
         GetQueryResultsRequest {
             project_id: self.project_id.clone(),
             job_id: self.job_id.clone(),
+            // Pass the job's location so the getQueryResults request includes the `location`
+            // query parameter. Jobs outside the default US region return a 404 without it.
+            location: Some(self.location.clone()),
             start_index: Some(self.page_start_index.clone().to_string()),
             max_results: Some(self.page_size),
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-bigquery",
 	"displayName": "Bigquery Data View",
 	"description": "Google BigQuery extension for Visual Studio Code. List datasets and tables, view table contents, and run queries.",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"publisher": "bstruct",
 	"icon": "logo.png",
 	"repository": {


### PR DESCRIPTION
Jobs created outside the default US region were returning a 404 because
the `getQueryResults` URL was built without the `location` query parameter.

- Added `location: Option<String>` field to `GetQueryResultsRequest`
- URL builder now appends `&location=<value>` when the field is present
- `as_query_results_request()` now passes the job's location from the element state

Ref: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults